### PR TITLE
Parse and truncate Woo data

### DIFF
--- a/truncate_merge_woo.py
+++ b/truncate_merge_woo.py
@@ -94,6 +94,12 @@ def truncate_merge_docs(length:int=10) -> None:
     save_docs(bodytext, f'{new_directory}/woo_bodytext.csv.gz')
     
     # Write document with all the data joined
+    # Create primary key for bodytext
+
+    bodytext.reset_index(inplace=True)
+    bodytext.index = bodytext['foi_documentId'] + ".pagina." + bodytext['foi_pageNumber'].astype(str)
+    bodytext.index.name = 'id'
+    
     # Prefix headers, so you know which columns come from which dataframe
     prefix_bodytext = 'bodytext_'
     exclude_bodytext = 'foi_documentId'
@@ -104,11 +110,11 @@ def truncate_merge_docs(length:int=10) -> None:
     documents.columns = [prefix_documents + col if col != exclude_documents else col for col in documents.columns]
 
     prefix_dossiers = 'dossiers_'
-    dossier_dataframe.columns = [prefix_dossiers + col for col in dossier_dataframe.columns]
+    dossiers.columns = [prefix_dossiers + col for col in dossiers.columns]
 
-    joined_bodytext_documents = bodytext.join(documents).reset_index()
-    result = pd.merge(joined_bodytext_documents, dossier_dataframe, left_on='foi_dossierId', right_on='dc_identifier')
-    result.set_index('foi_documentId', inplace=True)
+    joined_bodytext_documents = bodytext.join(documents, on='foi_documentId')
+    result = joined_bodytext_documents.join(dossiers, on='foi_dossierId')
+    
     save_docs(result, f'{new_directory}/woo_merged.csv.gz')
     
     logger.info(f"Truncated data successfully saved to {new_directory}.")

--- a/truncate_woo.py
+++ b/truncate_woo.py
@@ -1,0 +1,93 @@
+import time
+import os
+import pandas as pd
+from loguru import logger
+
+def select_woogle_dump_folders(path:str='./docs') -> str:
+    """
+    Look for folders containing "woogle_dump" in their names and return the selected folder.
+    """
+    if not os.path.exists(path) or not os.path.isdir(path):
+        logger.error(f'Path: "{path}" does not exist or is not a directory.')
+        return None
+    
+    # Look for folders containing "woogle_dump" in their names
+    folders_with_woogle_dump = [folder for folder in os.listdir(path) if os.path.isdir(os.path.join(path, folder)) and "woogle_dump" in folder]
+
+    print("Folders containing 'woogle_dump':")
+    for idx, folder in enumerate(folders_with_woogle_dump, start=1):
+        print(f"{idx}. {folder}")
+
+    if not folders_with_woogle_dump:
+        logger.error("No folders containing 'woogle_dump' were found.")
+        return None
+    
+    selection = int(input("Select a folder by number: ")) - 1
+    return f"{path}/{folders_with_woogle_dump[selection]}"
+
+def read_docs(path:str) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """"
+    Reads the bodytext, dossier and document csv files from the given path and returns them as dataframes.
+    """
+    # Manually set the correct types
+    bodytext_dtypes = {'dc_publisher_name': str, 'dc_publisher': str, 'foi_documentId': str, 'foi_pageNumber': int, 'foi_bodyText': str, 'foi_bodyTextOCR': str, 'foi_hasOCR': bool, 'foi_redacted': float, 'foi_contourArea': float, 'foi_textArea': float, 'foi_charArea': float, 'foi_percentageTextAreaRedacted': float, 'foi_percentageCharAreaRedacted': float, 'foi_nrWords': int, 'foi_nrChars': int, 'foi_nrWordsOCR ': int, 'foi_nrCharsOCR': int}
+    dossier_dtypes = {'dc_identifier': str, 'dc_title': str, 'dc_description': str, 'dc_type': str, 'foi_type_description': str, 'dc_publisher_name': str, 'dc_publisher': str, 'dc_source': str, 'foi_valuation': str, 'foi_requestText': str, 'foi_decisionText': str, 'foi_isAdjourned': str, 'foi_requester': str}
+    document_dtypes = {'dc_identifier': str, 'foi_dossierId': str, 'dc_title': str, 'foi_fileName': str, 'dc_format': str, 'dc_source': str, 'dc_type': str, 'foi_nrPages': int}
+    
+    # Start recording the time
+    start_time = time.time()
+    logger.info(f"Reading data from {path}...")
+    
+    bodytext_dataframe = pd.read_csv(f'{path}/woo_bodytext.csv.gz', dtype=bodytext_dtypes).set_index('foi_documentId')
+    # Manually changes some columns, has to be done seperately due to nan values
+    bodytext_dataframe['foi_redacted'] = bodytext_dataframe['foi_redacted'].astype(bool)
+    dossier_dataframe = pd.read_csv(f'{path}/woo_dossiers.csv.gz', parse_dates=['foi_publishedDate', 'dc_date_year', 'foi_requestDate', 'foi_decisionDate', 'foi_retrievedDate'], dtype=dossier_dtypes).set_index('dc_identifier')
+    document_dataframe = pd.read_csv(f'{path}/woo_documents.csv.gz', dtype=document_dtypes).set_index('dc_identifier')
+    
+    # Log time it took
+    logger.info(f"Data read in {time.time() - start_time:.2f} seconds.")
+    
+    return bodytext_dataframe, dossier_dataframe, document_dataframe
+
+def save_docs(df:pd.DataFrame, filename:str) -> None:
+    """
+    Saves the given dataframe to the given filename. If the file already exists, it will not be overwritten.
+    """
+    if not os.path.exists(filename):
+        df.to_csv(filename, compression='gzip')
+    else:
+        logger.warning(f"Skipping file as it already exists at location: {filename}")
+
+def truncate_docs(length:int=10) -> None:
+    """
+    Truncates the bodytext, dossier and document dataframes to the given length and saves them in a new directory.
+    """
+    path = select_woogle_dump_folders()
+    if path is None:
+        logger.error("No folder was selected. Exiting...")
+        return
+
+    bodytext_dataframe, dossier_dataframe, document_dataframe = read_docs(path)
+
+    # Define the new directory based on path and length
+    new_directory = f"{path}_{length}"
+
+    # Check if the directory exists, if not, create it
+    if not os.path.exists(new_directory):
+        os.makedirs(new_directory)
+
+    # Get the dc_identifier of the first "n = length" dossiers
+    dossiers = dossier_dataframe.head(length)
+    save_docs(dossiers, f'{new_directory}/woo_dossiers.csv.gz')
+    
+    # Only use the documents and bodytext that are in the selected dossiers
+    documents = document_dataframe[document_dataframe['foi_dossierId'].isin(dossiers.index)]
+    save_docs(documents, f'{new_directory}/woo_documents.csv.gz')
+
+    bodytext = bodytext_dataframe[bodytext_dataframe.index.isin(documents.index)]
+    save_docs(bodytext, f'{new_directory}/woo_bodytext.csv.gz')
+    
+    logger.info(f"Truncated data successfully saved to {new_directory}.")
+
+if __name__ == "__main__":
+    truncate_docs()


### PR DESCRIPTION
The `truncate_merge_woo.py` file parses the WoogleDumps in such a way that they are usable directly to ingest with `ingest.py` (also see: https://github.com/SSC-ICT-Innovatie/LearningLion/pull/5). It also provides the feature to make the data set smaller. The size is on default set on 10 dossiers, but it's easily adjustable (note: 10 dossiers still correspond to ~4000 pages).

How to test:
1. Download the whole WoogleDump named WoogleDumps_11-01-2024.zip: https://drive.google.com/drive/u/1/folders/1diJMYlRhKEvOfdzxCyrSbSjUlmeP8ybq.
2. Unzip the contents, and place it in a new folder named WoogleDumps_11-01-2024 in `/docs`.
3. Run `python Truncate_merge_woo.py`, and follow the steps (i.e. it looks for the folders containing the name "WoogleDumps", and let's you select the correct folder).
4. The result should be a new folder `WoogleDumps_11-01-2024_10`, with the truncated and parsed data.

Requirements:
This code took me about 20 minutes to run on an Intel Core i7-8750H (hexa-core) Coffee Lake with 16GB of DDR4 RAM, under Windows 10 Pro (64-bit). If your ram is <16GB, the code is likely to crash if you run it while other applications are open that consume your ram (trust me, I speak of experience).