### PR TITLE
Ingest Woo data

### DIFF
--- a/ingest/ingester.py
+++ b/ingest/ingester.py
@@ -12,7 +12,9 @@ import settings
 # from ingest.content_iterator import ContentIterator
 from ingest.ingest_utils import IngestUtils
 from ingest.file_parser import FileParser
+from ingest.woo_parser import WooParser
 import utils as ut
+import pandas as pd
 
 
 class Ingester:
@@ -23,7 +25,7 @@ class Ingester:
     def __init__(self, collection_name: str, content_folder: str, vectordb_folder: str,
                  embeddings_provider=None, embeddings_model=None, text_splitter_method=None,
                  vecdb_type=None, chunk_size=None, chunk_overlap=None, local_api_url=None,
-                 file_no=None, azureopenai_api_version=None):
+                 file_no=None, azureopenai_api_version=None, data_type=None):
         load_dotenv()
         self.collection_name = collection_name
         self.content_folder = content_folder
@@ -41,8 +43,21 @@ class Ingester:
         self.azureopenai_api_version = settings.AZUREOPENAI_API_VERSION \
             if azureopenai_api_version is None and settings.AZUREOPENAI_API_VERSION is not None \
             else azureopenai_api_version
+        self.data_type = settings.DATA_TYPE if data_type is None else data_type
 
     def ingest(self) -> None:
+        """
+        Chooses the right method to ingest the data
+        """
+        match self.data_type:
+            case "woo":
+                logger.info("Ingesting woo data")
+                self.ingest_woo()
+            case _:
+                logger.info("Ingesting standard data")
+                self.ingest_standard()
+
+    def ingest_standard(self) -> None:
         """
         Creates file parser object and ingestutils object and iterates over all files in the folder
         Checks are done whether vector store needs to be synchronized with folder contents
@@ -137,3 +152,79 @@ class Ingester:
 
             # save updated vector store to disk
             vector_store.persist()
+
+    def ingest_woo(self) -> None:
+        woo_parser = WooParser()
+        ingestutils = IngestUtils(self.chunk_size, self.chunk_overlap, self.file_no, self.text_splitter_method)
+
+        # Get embeddings
+        embeddings = ut.getEmbeddings(self.embeddings_provider, self.embeddings_model, self.local_api_url, self.azureopenai_api_version)
+        
+        if self.vecdb_type == "chromadb":
+            # Set the datatypes for the columns
+            dtypes={"id": str, "foi_documentId": str, "foi_dossierId": str, "bodytext_foi_pageNumber": int, "bodytext_foi_bodyText": str, "bodytext_foi_bodyTextOCR": str, "bodytext_foi_hasOCR": bool, "bodytext_foi_redacted": float, "bodytext_foi_nrRedactedRegions": int, "bodytext_foi_contourArea": float, "bodytext_foi_textArea": float, "bodytext_foi_charArea": float, "bodytext_foi_percentageTextAreaRedacted": float, "bodytext_foi_percentageCharAreaRedacted": float, "bodytext_foi_imageArea": int, "bodytext_foi_imageCoversFullPage": int, "bodytext_foi_bodyTextJaccard": float, "documents_dc_title": str, "documents_dc_description": str, "documents_foi_fileName": str, "documents_dc_format": str, "documents_dc_source": str, "documents_dc_type": str, "documents_foi_nrPages": int, "documents_foi_pdfDateCreated": str, "documents_foi_pdfDateModified": str, "documents_foi_pdfCreator": str, "documents_foi_pdfProducer": str, "documents_foi_pdfAuthor": str, "documents_foi_pdfCompany": str, "documents_foi_pdfTitle": str, "documents_foi_pdfSubject": str, "documents_foi_pdfKeywords": str, "documents_foi_fairiscore": int, "dossiers_dc_title": str, "dossiers_dc_description": str, "dossiers_dc_type": str, "dossiers_dc_type_description": str, "dossiers_dc_publisher": str, "dossiers_dc_publisher_name": str, "dossiers_dc_source": str, "dossiers_foi_valuation": str, "dossiers_foi_requestText": str, "dossiers_foi_decisionText": str, "dossiers_foi_isAdjourned": str, "dossiers_foi_requester": str, "dossiers_foi_fairiscore": int, "dossiers_tooiwl_rubriek": str, "dossiers_tooiwl_rubriekCode": str, "dossiers_foi_geoInfo": str}
+            woo_data = pd.read_csv(f'{self.content_folder}/woo_merged.csv.gz', parse_dates=['dossiers_foi_publishedDate', 'dossiers_dc_date_year', 'dossiers_foi_requestDate', 'dossiers_foi_decisionDate', 'dossiers_foi_retrievedDate'], dtype=dtypes).set_index('id')
+            
+            # If the vector store already exists, get the set of ingested files from the vector store
+            if os.path.exists(self.vectordb_folder):
+                vector_store = ut.get_chroma_vector_store(self.collection_name, embeddings, self.vectordb_folder)
+                # Determine the files that are added or deleted
+                collection = vector_store.get()  # dict_keys(['ids', 'embeddings', 'documents', 'metadatas'])
+                collection_ids = [int(id) for id in collection['ids']]
+                files_in_store = [metadata['id'] for metadata in collection['metadatas']]
+                files_in_store = list(set(files_in_store))
+                # Check if there are any deleted items
+                files_deleted = [file for file in files_in_store if file not in woo_data.index]
+                if len(files_deleted) > 0:
+                    logger.info(f"Files are deleted, so vector store for {self.content_folder} needs to be updated")
+                    idx_id_to_delete = []
+                    for idx in range(len(collection['ids'])):
+                        idx_id = collection['ids'][idx]
+                        idx_metadata = collection['metadatas'][idx]
+                        if idx_metadata['id'] in files_deleted:
+                            idx_id_to_delete.append(idx_id)
+                    print(idx_id_to_delete)
+                    vector_store.delete(idx_id_to_delete)
+                    logger.info("Deleted files from vectorstore")
+                # Check if there is new data and only keep the new data
+                woo_data = woo_data.drop(files_in_store, errors='ignore')
+                collection = vector_store.get()  # dict_keys(['ids', 'embeddings', 'documents', 'metadatas'])
+                collection_ids = [int(id) for id in collection['ids']]
+                start_id = max(collection_ids) + 1
+            # Else it needs to be created first
+            else:
+                logger.info(f"Vector store to be created for folder {self.content_folder}")
+                # Get chroma vector store
+                vector_store = ut.get_chroma_vector_store(self.collection_name, embeddings, self.vectordb_folder)
+                collection = vector_store.get()  # dict_keys(['ids', 'embeddings', 'documents', 'metadatas'])
+                start_id = 0
+                
+            if len(woo_data) > 0:
+                logger.info(f"Files are added, so vector store for {self.content_folder} needs to be updated")
+                for index, row in woo_data.reset_index().iterrows():
+                    # Extract raw text pages and metadata
+                    raw_pages, metadata = woo_parser.parse_woo(row)
+                    if raw_pages is None or metadata is None:
+                        continue
+                    
+                    # Convert the raw text to cleaned text chunks
+                    documents = ingestutils.clean_text_to_docs(raw_pages, metadata)
+                    if len(documents) == 0:
+                        continue
+                    
+                    vector_store.add_documents(
+                        documents=documents,
+                        embedding=embeddings,
+                        collection_name=self.collection_name,
+                        persist_directory=self.vectordb_folder,
+                        ids=[str(id) for id in list(range(start_id, start_id + len(documents)))]
+                    )
+                    collection = vector_store.get()
+                    collection_ids = [int(id) for id in collection['ids']]
+                    start_id = max(collection_ids) + 1
+                logger.info("Added files to vectorstore")
+                
+                # Save updated vector store to disk
+                vector_store.persist()
+            else:
+                logger.warning(f"No new woo documents to be ingested")

--- a/ingest/woo_parser.py
+++ b/ingest/woo_parser.py
@@ -1,0 +1,43 @@
+from typing import Dict, List, Tuple
+import pandas as pd
+import numpy as np
+
+class WooParser:
+    """
+    A class with functionality to parse woo documents
+    """
+    
+    def convert_nat_to_nan(self, obj: Dict[str, any]) -> None:
+        for key, value in obj.items():
+            if pd.isna(value):
+                obj[key] = np.nan
+                
+    def convert_timestamp_to_str(self, obj: Dict[str, any]) -> None:
+        for key, value in obj.items():
+            if isinstance(value, pd.Timestamp):
+                # Convert to string using a specific format (e.g., ISO format)
+                obj[key] = value.strftime('%Y-%m-%d %H:%M:%S')
+
+    def parse_woo(self, woo: pd.core.series.Series) -> Tuple[List[Tuple[int, str]], Dict[str, any]]:
+        woo_json = woo.to_dict()
+        
+        # Check if 'bodytext_foi_bodyText' exists and is not NaN
+        if 'bodytext_foi_bodyText' in woo_json and not pd.isna(woo_json['bodytext_foi_bodyText']):
+            raw_text = woo_json['bodytext_foi_bodyText']
+        # If the above condition is not met, check 'bodytext_foi_bodyTextOCR'
+        elif 'bodytext_foi_bodyTextOCR' in woo_json and not pd.isna(woo_json['bodytext_foi_bodyTextOCR']):
+            raw_text = woo_json['bodytext_foi_bodyTextOCR']
+        else:
+            return None, None
+        
+        # Delete keys if they exist in woo_json
+        woo_json.pop('bodytext_foi_bodyText', None)
+        woo_json.pop('bodytext_foi_bodyTextOCR', None)
+                
+        # Convert 'NaT' to 'NaN' in the dictionary, and timestamps to string
+        self.convert_nat_to_nan(woo_json)
+        self.convert_timestamp_to_str(woo_json)
+        
+        # Return 0 tuple, because the way we are currently preprocessing, we only have 1 page.        
+        return [(0, raw_text)], woo_json
+    

--- a/settings_template.py
+++ b/settings_template.py
@@ -7,6 +7,9 @@ APP_INFO = "./info/explanation.txt"
 # header in Streamlit UI, e.g. "ChatNMDC: chat with your documents"
 APP_HEADER = "ChatNMDC: chat with your documents"
 
+# must be "woo", if working with the Woo dataset. Otherwise it will use the default ingester.
+DATA_TYPE = ""
+
 # relative filepath of folder with input documents, e.g. "./docs"
 DOC_DIR = "./docs"
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -133,13 +133,20 @@ def handle_query(my_querier, my_prompt: str):
     st.session_state['messages'].append({"role": "assistant", "content": response["answer"]})
     if len(response["source_documents"]) > 0:
         with st.expander("Paragraphs used for answer"):
-            cnt = 0
-            for document in response["source_documents"]:
-                st.markdown(f'''**page: {document.metadata['page_number']},
-                            chunk: {document.metadata['chunk']},
-                            score: {scores[cnt]:.4f},
-                            file: {document.metadata['filename']}**''')
-                cnt += 1
+            for index, document in enumerate(response["source_documents"]):
+                if index != 0:
+                    st.markdown("---")
+                if settings.DATA_TYPE == "woo":
+                    source_link = f', source: [link]({document.metadata["documents_dc_source"]})' if document.metadata.get("documents_dc_source") else ""
+                    st.markdown(f'''**id: {document.metadata['id']},
+                                chunk: {document.metadata['chunk']},
+                                score: {scores[index]:.4f},
+                                dossiers_dc_title: {document.metadata['dossiers_dc_title']}{source_link}**  ''')
+                else:
+                    st.markdown(f'''**page: {document.metadata['page_number']},
+                                chunk: {document.metadata['chunk']},
+                                score: {scores[index]:.4f},
+                                file: {document.metadata['filename']}**''')
                 st.markdown(f"{document.page_content}")
     else:
         logger.info("No source documents found relating to the question")


### PR DESCRIPTION
This pull request provides the feature to ingest the Woo-data, based on dataframes, instead of .txt files (also see: https://github.com/SSC-ICT-Innovatie/LearningLion/pull/4). This way, it is possible to maintain metadata, which is not possible with .txt files.

How to test:
1. Update your `settings.py` just like the `settings_template.py` (i.e., copy this in your `settings.py`: `DATA_TYPE = "woo"`
2. Follow the instructions from https://github.com/SSC-ICT-Innovatie/LearningLion/pull/4, to create a smaller dataset. Alternatively, download the smaller dataset from https://drive.google.com/drive/u/1/folders/1diJMYlRhKEvOfdzxCyrSbSjUlmeP8ybq.
3. Run `streamlit run streamlit_app.py`.
4. You should be able to talk with your documents now.