### PR TITLE
Support multiple pages Woo Data

### DIFF
--- a/ingest/ingester.py
+++ b/ingest/ingester.py
@@ -15,6 +15,7 @@ from ingest.file_parser import FileParser
 from ingest.woo_parser import WooParser
 import utils as ut
 import pandas as pd
+import numpy as np
 
 
 class Ingester:
@@ -165,29 +166,38 @@ class Ingester:
             dtypes={"id": str, "foi_documentId": str, "foi_dossierId": str, "bodytext_foi_pageNumber": int, "bodytext_foi_bodyText": str, "bodytext_foi_bodyTextOCR": str, "bodytext_foi_hasOCR": bool, "bodytext_foi_redacted": float, "bodytext_foi_nrRedactedRegions": int, "bodytext_foi_contourArea": float, "bodytext_foi_textArea": float, "bodytext_foi_charArea": float, "bodytext_foi_percentageTextAreaRedacted": float, "bodytext_foi_percentageCharAreaRedacted": float, "bodytext_foi_imageArea": int, "bodytext_foi_imageCoversFullPage": int, "bodytext_foi_bodyTextJaccard": float, "documents_dc_title": str, "documents_dc_description": str, "documents_foi_fileName": str, "documents_dc_format": str, "documents_dc_source": str, "documents_dc_type": str, "documents_foi_nrPages": int, "documents_foi_pdfDateCreated": str, "documents_foi_pdfDateModified": str, "documents_foi_pdfCreator": str, "documents_foi_pdfProducer": str, "documents_foi_pdfAuthor": str, "documents_foi_pdfCompany": str, "documents_foi_pdfTitle": str, "documents_foi_pdfSubject": str, "documents_foi_pdfKeywords": str, "documents_foi_fairiscore": int, "dossiers_dc_title": str, "dossiers_dc_description": str, "dossiers_dc_type": str, "dossiers_dc_type_description": str, "dossiers_dc_publisher": str, "dossiers_dc_publisher_name": str, "dossiers_dc_source": str, "dossiers_foi_valuation": str, "dossiers_foi_requestText": str, "dossiers_foi_decisionText": str, "dossiers_foi_isAdjourned": str, "dossiers_foi_requester": str, "dossiers_foi_fairiscore": int, "dossiers_tooiwl_rubriek": str, "dossiers_tooiwl_rubriekCode": str, "dossiers_foi_geoInfo": str}
             woo_data = pd.read_csv(f'{self.content_folder}/woo_merged.csv.gz', parse_dates=['dossiers_foi_publishedDate', 'dossiers_dc_date_year', 'dossiers_foi_requestDate', 'dossiers_foi_decisionDate', 'dossiers_foi_retrievedDate'], dtype=dtypes).set_index('id')
             
+            # First merge all the different pages of a document into one row
+            woo_data['all_foi_bodyText'] = np.where(woo_data['bodytext_foi_bodyText'].notnull() & woo_data['bodytext_foi_bodyText'].str.strip().ne(''), woo_data['bodytext_foi_bodyText'], woo_data['bodytext_foi_bodyTextOCR'])
+            grouped_bodyText = woo_data.groupby('foi_documentId')['all_foi_bodyText'].apply(list).reset_index()
+            unique_woo_data = woo_data.drop_duplicates(subset='foi_documentId')
+            parsed_woo_data = pd.merge(unique_woo_data.reset_index(), grouped_bodyText, on='foi_documentId', how='left', suffixes=('', '_grouped'))
+            
+            # Only keep the relevant data
+            filtered_woo_data = parsed_woo_data[['foi_documentId', 'foi_dossierId', 'documents_dc_title', 'documents_dc_description', 'documents_foi_fileName', 'documents_dc_format', 'documents_dc_source', 'documents_dc_type', 'documents_foi_nrPages', 'documents_foi_pdfDateCreated', 'documents_foi_pdfDateModified', 'documents_foi_pdfCreator', 'documents_foi_pdfProducer', 'documents_foi_pdfAuthor', 'documents_foi_pdfCompany', 'documents_foi_pdfTitle', 'documents_foi_pdfSubject', 'documents_foi_pdfKeywords', 'dossiers_dc_title', 'dossiers_dc_description', 'dossiers_dc_type', 'dossiers_dc_type_description', 'dossiers_dc_publisher', 'dossiers_dc_publisher_name', 'dossiers_dc_source', 'dossiers_foi_publishedDate', 'dossiers_dc_date_year', 'dossiers_foi_requestDate', 'dossiers_foi_decisionDate', 'dossiers_foi_valuation', 'dossiers_foi_requestText', 'dossiers_foi_decisionText', 'dossiers_foi_isAdjourned', 'dossiers_foi_requester', 'dossiers_foi_retrievedDate', 'dossiers_tooiwl_rubriek', 'dossiers_tooiwl_rubriekCode', 'dossiers_foi_geoInfo', 'all_foi_bodyText_grouped']]
+            woo_data = filtered_woo_data.rename(columns={'all_foi_bodyText_grouped': 'all_foi_bodyText'})
+            
             # If the vector store already exists, get the set of ingested files from the vector store
             if os.path.exists(self.vectordb_folder):
                 vector_store = ut.get_chroma_vector_store(self.collection_name, embeddings, self.vectordb_folder)
                 # Determine the files that are added or deleted
                 collection = vector_store.get()  # dict_keys(['ids', 'embeddings', 'documents', 'metadatas'])
                 collection_ids = [int(id) for id in collection['ids']]
-                files_in_store = [metadata['id'] for metadata in collection['metadatas']]
+                files_in_store = [metadata['foi_documentId'] for metadata in collection['metadatas']]
                 files_in_store = list(set(files_in_store))
                 # Check if there are any deleted items
-                files_deleted = [file for file in files_in_store if file not in woo_data.index]
+                files_deleted = [file for file in files_in_store if file not in woo_data['foi_documentId'].tolist()]
                 if len(files_deleted) > 0:
                     logger.info(f"Files are deleted, so vector store for {self.content_folder} needs to be updated")
                     idx_id_to_delete = []
                     for idx in range(len(collection['ids'])):
                         idx_id = collection['ids'][idx]
                         idx_metadata = collection['metadatas'][idx]
-                        if idx_metadata['id'] in files_deleted:
+                        if idx_metadata['foi_documentId'] in files_deleted:
                             idx_id_to_delete.append(idx_id)
-                    print(idx_id_to_delete)
                     vector_store.delete(idx_id_to_delete)
                     logger.info("Deleted files from vectorstore")
                 # Check if there is new data and only keep the new data
-                woo_data = woo_data.drop(files_in_store, errors='ignore')
+                woo_data = woo_data[~woo_data['foi_documentId'].isin(files_in_store)]
                 collection = vector_store.get()  # dict_keys(['ids', 'embeddings', 'documents', 'metadatas'])
                 collection_ids = [int(id) for id in collection['ids']]
                 if len(collection_ids) == 0:
@@ -212,8 +222,6 @@ class Ingester:
                     
                     # Convert the raw text to cleaned text chunks
                     documents = ingestutils.clean_text_to_docs(raw_pages, metadata)
-                    if len(documents) == 0:
-                        continue
                     
                     vector_store.add_documents(
                         documents=documents,

--- a/ingest/ingester.py
+++ b/ingest/ingester.py
@@ -190,7 +190,10 @@ class Ingester:
                 woo_data = woo_data.drop(files_in_store, errors='ignore')
                 collection = vector_store.get()  # dict_keys(['ids', 'embeddings', 'documents', 'metadatas'])
                 collection_ids = [int(id) for id in collection['ids']]
-                start_id = max(collection_ids) + 1
+                if len(collection_ids) == 0:
+                    start_id = 0
+                else:
+                    start_id = max(collection_ids) + 1
             # Else it needs to be created first
             else:
                 logger.info(f"Vector store to be created for folder {self.content_folder}")

--- a/ingest/woo_parser.py
+++ b/ingest/woo_parser.py
@@ -9,6 +9,9 @@ class WooParser:
     
     def convert_nat_to_nan(self, obj: Dict[str, any]) -> None:
         for key, value in obj.items():
+            # Skip the value if it is a list
+            if isinstance(value, list):
+                continue
             if pd.isna(value):
                 obj[key] = np.nan
                 
@@ -21,23 +24,21 @@ class WooParser:
     def parse_woo(self, woo: pd.core.series.Series) -> Tuple[List[Tuple[int, str]], Dict[str, any]]:
         woo_json = woo.to_dict()
         
-        # Check if 'bodytext_foi_bodyText' exists and is not NaN
-        if 'bodytext_foi_bodyText' in woo_json and not pd.isna(woo_json['bodytext_foi_bodyText']):
-            raw_text = woo_json['bodytext_foi_bodyText']
-        # If the above condition is not met, check 'bodytext_foi_bodyTextOCR'
-        elif 'bodytext_foi_bodyTextOCR' in woo_json and not pd.isna(woo_json['bodytext_foi_bodyTextOCR']):
-            raw_text = woo_json['bodytext_foi_bodyTextOCR']
-        else:
+        if 'all_foi_bodyText' not in woo_json or len(woo_json['all_foi_bodyText']) == 0:
             return None, None
         
-        # Delete keys if they exist in woo_json
-        woo_json.pop('bodytext_foi_bodyText', None)
-        woo_json.pop('bodytext_foi_bodyTextOCR', None)
-                
+        # Create a tuple with the index and the bodyText
+        tuple_bodyText = [(i, s) for i, s in enumerate(woo_json['all_foi_bodyText'])]
+        
+        if len(tuple_bodyText) == 0:
+            return None, None
+        
+        # Delete the 'all_foi_bodyText' key from the dictionary
+        woo_json.pop('all_foi_bodyText', None)
+
         # Convert 'NaT' to 'NaN' in the dictionary, and timestamps to string
         self.convert_nat_to_nan(woo_json)
         self.convert_timestamp_to_str(woo_json)
-        
-        # Return 0 tuple, because the way we are currently preprocessing, we only have 1 page.        
-        return [(0, raw_text)], woo_json
+       
+        return tuple_bodyText, woo_json
     

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -138,10 +138,11 @@ def handle_query(my_querier, my_prompt: str):
                     st.markdown("---")
                 if settings.DATA_TYPE == "woo":
                     source_link = f', source: [link]({document.metadata["documents_dc_source"]})' if document.metadata.get("documents_dc_source") else ""
-                    st.markdown(f'''**id: {document.metadata['id']},
+                    st.markdown(f'''**Document id: {document.metadata['foi_documentId']},
+                                page: {document.metadata['page_number']},
                                 chunk: {document.metadata['chunk']},
                                 score: {scores[index]:.4f},
-                                dossiers_dc_title: {document.metadata['dossiers_dc_title']}{source_link}**  ''')
+                                dossier: {document.metadata['dossiers_dc_title']}{source_link}**  ''')
                 else:
                     st.markdown(f'''**page: {document.metadata['page_number']},
                                 chunk: {document.metadata['chunk']},


### PR DESCRIPTION
This pull request is an addition to https://github.com/SSC-ICT-Innovatie/LearningLion/pull/5. It fixes a small bug where if you deleted all entries from a vector database, and then tried to add new entries to it, it would error. Furthermore, this pull request adds the functionality to parse multiple pages of woo-request into a single document, rather than parsing all of them one by one. This is handy, because embedding will now go _slightly_ faster, and when retrieving the results, you can now also specify what page the origin of the answer was.

How to test (Note that this is the same as https://github.com/SSC-ICT-Innovatie/LearningLion/pull/5):
1. Update your `settings.py` just like the `settings_template.py` (i.e., copy this in your `settings.py`: `DATA_TYPE = "woo"`
2. Follow the instructions from https://github.com/SSC-ICT-Innovatie/LearningLion/pull/4, to create a smaller dataset. Alternatively, download the smaller dataset from https://drive.google.com/drive/u/1/folders/1diJMYlRhKEvOfdzxCyrSbSjUlmeP8ybq.
3. Run `streamlit run streamlit_app.py`.
4. You should be able to talk with your documents now.